### PR TITLE
add coral switcher in launch file

### DIFF
--- a/jsk_2023_04_human_approach/config/coral.yaml
+++ b/jsk_2023_04_human_approach/config/coral.yaml
@@ -1,0 +1,7 @@
+edgetpu_node_manager:
+  nodes:
+  - name: edgetpu_panorama_object_detector
+    type: panorama_object_detector
+  - name: edgetpu_human_pose_estimator
+    type: human_pose_estimator
+  default: edgetpu_panorama_object_detector

--- a/jsk_2023_04_human_approach/launch/recognition.launch
+++ b/jsk_2023_04_human_approach/launch/recognition.launch
@@ -46,20 +46,24 @@
   </node>
 
 
-  <!-- Detector -->
-  <!-- <include if="$(arg coral)" file="$(find coral_usb)/launch/edgetpu_panorama_object_detector.launch"> -->
-  <!--   <arg name="INPUT_IMAGE" value="/dual_fisheye_to_panorama/output"/> -->
-  <!-- </include> -->
-  <include if="$(arg coral)" file="$(find coral_usb)/launch/edgetpu_human_pose_estimator.launch">
-    <arg name="INPUT_IMAGE" value="/spot/camera/hand_color/image"/>
+  <!-- Detector -->  
+  <!-- IMAGE mux for coral input -->
+  <node pkg="topic_tools"
+	type="mux"
+	name="coral_input_image_mux"
+	args="/coral_input/image /dual_fisheye_to_panorama/output /spot/camera/hand_color/image mux:=coral_input/image" />
+  <!-- launch coral -->
+  <include if="$(arg coral)" file="$(find coral_usb)/launch/edgetpu_node_manager.launch">
+    <arg name="INPUT_IMAGE" value="/coral_input/image" />
+    <arg name="YAML_PATH" value="$(find jsk_2023_04_human_approach)/config/coral.yaml" />
   </include>
+  <!-- publish 3D skeletons -->
   <node pkg="jsk_perception"
 	type="skeleton_with_depth.py"
 	name="skeleton_with_depth">
-    <remap from="~input/skeleton" to="/edgetpu_human_pose_estimator/output/skels" />
+    <remap from="~input/skeleton" to="/edgetpu_human_pose_estimator/output/skeletons" />
     <remap from="~input/depth" to="/spot/camera/hand_depth/depth_registered/image" />
     <remap from="~input/info" to="/spot/camera/hand_depth/camera_info" />
-    <!-- <remap from="~output/skeleton" to="" /> -->
   </node>
 
 </launch>


### PR DESCRIPTION
## Background
We had to comment in either `edgetpu_panorama_object_detector.launch` or `edgetpu_human_pose_estimator` because the coral TPU couldn't handle 2 nodes at the same time.

## What is this?
This PR adds `topic_tools mux` and `edgetpu_node_manager` to solve this problem.

I'll show shell example to call rosservice. Please try with [euslisp](http://wiki.ros.org/ROS/Tutorials/WritingServiceClient%28euslisp%29).  If you want to detect human with insta360, call the 2 services like
```bash
rosservice call /coral_input/image/select "topic: '/dual_fisheye_to_panorama/output'"
rosservice call /edgetpu_node_manager/start "name: 'edgetpu_panorama_object_detector'"
```
if you want to detect human skel with hand camera, call the 2 services
```bash
rosservice call /coral_input/image/select "topic: '/spot/camera/hand_color/image'"
rosservice call /edgetpu_node_manager/start "name: 'edgetpu_human_pose_estimator'"
```
